### PR TITLE
First draft commit

### DIFF
--- a/armada_jupyter/constants.py
+++ b/armada_jupyter/constants.py
@@ -1,4 +1,8 @@
 class YMLSTR:
+    """
+    This class is used to store the yml strings for the different
+    services that are used in the armada-jupyter config.
+    """
 
     submissions = "submissions"
 

--- a/armada_jupyter/constants.py
+++ b/armada_jupyter/constants.py
@@ -1,0 +1,25 @@
+class YMLSTR:
+
+    submissions = "submissions"
+
+    name = "name"
+    image = "image"
+    armada_queue = "armada_queue"
+    armada_priority = "armada_priority"
+    timeout = "timeout"
+    resources = "resources"
+
+    limits = "limits"
+    requests = "requests"
+    cpu = "cpu"
+    memory = "memory"
+    nvidia_gpu = "nvidia.com/gpu"
+    amd_gpu = "amd.com/gpu"
+
+
+DEFAULT_QUEUE = "default"
+DEFAULT_PRIORITY = 1
+DEFAULT_TIMEOUT = "1h"
+
+DEFAULT_MEMORY = "1Gi"
+DEFAULT_CPU = 1

--- a/armada_jupyter/submissions.py
+++ b/armada_jupyter/submissions.py
@@ -1,0 +1,205 @@
+from typing import List, Optional, Dict, Union
+
+import yaml
+
+from armada_jupyter.constants import (
+    YMLSTR,
+    DEFAULT_QUEUE,
+    DEFAULT_PRIORITY,
+    DEFAULT_TIMEOUT,
+    DEFAULT_MEMORY,
+    DEFAULT_CPU,
+)
+
+
+class K8sResourceOptions:
+    """
+    Manages the options for a kubernetes resource request or limit
+    """
+
+    def __init__(
+        self,
+        cpu: int,
+        memory: str,
+        nvidia_gpu: Union[str, int, None] = None,
+        amd_gpu: Union[str, int, None] = None,
+    ):
+        self.cpu = cpu
+        self.memory = memory
+        self.nvidia_gpu = nvidia_gpu
+        self.amd_gpu = amd_gpu
+
+        # If they exist, they might be a string, so we need to convert them to int
+        if self.nvidia_gpu:
+            self.nvidia_gpu = int(self.nvidia_gpu)
+
+        if self.amd_gpu:
+            self.amd_gpu = int(self.amd_gpu)
+
+    def __repr__(self) -> str:
+        return (
+            f"K8sResourceOptions({YMLSTR.cpu}={self.cpu}, {YMLSTR.memory}='{self.memory}', "
+            f"{YMLSTR.nvidia_gpu}={self.nvidia_gpu}, {YMLSTR.amd_gpu}={self.amd_gpu})"
+        )
+
+
+class K8sResources:
+    """
+    Manages the resources for a Kubernetes pod ran by Armada
+    """
+
+    def __init__(
+        self, limits: K8sResourceOptions = None, requests: K8sResourceOptions = None
+    ):
+        if limits is None and requests is None:
+            raise ValueError("Must specify at least one of limits or requests")
+
+        self.limits = limits
+        self.requests = limits
+
+    def __repr__(self) -> str:
+        return f"K8sResources({YMLSTR.limits}={self.limits}, {YMLSTR.requests}={self.requests})"
+
+
+class Submission:
+    """
+    Represents a Armada-Jupyter Submission
+    """
+
+    def __init__(
+        self,
+        name: str,
+        image: str,
+        armada_queue: str,
+        armada_priority: int,
+        timeout: str,
+        resources: Optional[K8sResources] = None,
+    ):
+        self.name = name
+        self.image = image
+        self.armada_queue = armada_queue
+        self.armada_priority = armada_priority
+        self.timeout = self.timeout_conversion(timeout)
+        self.resources = resources
+
+        # Check that resources is the right object
+        if not isinstance(resources, K8sResources) and resources is not None:
+            raise ValueError(
+                f"resources must be a K8sResources object, not {type(resources)}"
+            )
+
+    @staticmethod
+    def timeout_conversion(timeout: str) -> Optional[str]:
+        """
+        Convert timeout from minutes and hours into seconds.
+
+        timeout can be in the form of 10m or 5h for example
+
+        should return a string like 100s
+        """
+
+        if timeout[-1] == "m":
+            return str(int(timeout[:-1]) * 60) + "s"
+        elif timeout[-1] == "h":
+            return str(int(timeout[:-1]) * 60 * 60) + "s"
+        elif timeout[-1] == "s":
+            return timeout
+
+        ValueError("Timeout must be in the form of [x]h, [x]m or [x]s")
+        return None
+
+    def resources_from_dict(
+        self, resources: Dict[str, Dict[str, Union[str, int]]]
+    ) -> None:
+        """
+        Used for adding a resources from dict
+        """
+
+        self.resources = k8s_resources_from_dict(
+            limits=resources.get(YMLSTR.limits),
+            requests=resources.get(YMLSTR.requests),
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"Submission(f{YMLSTR.name}='{self.name}', {YMLSTR.image}='{self.image}' "
+            f"{YMLSTR.armada_queue}='{self.armada_queue}', "
+            f"{YMLSTR.armada_priority}={self.armada_priority}, "
+            f"{YMLSTR.timeout}='{self.timeout}', {YMLSTR.resources}={self.resources})"
+        )
+
+
+def k8s_resources_from_dict(
+    limits: Optional[Dict[str, Union[str, int]]] = None,
+    requests: Optional[Dict[str, Union[str, int]]] = None,
+) -> K8sResources:
+    """
+    Creates a K8sResources object from a dict
+    """
+
+    changed: Dict[str, Optional[K8sResourceOptions]] = {}
+
+    if limits is None and requests is None:
+        raise ValueError("Must specify at least one of limits or requests")
+
+    # Use a loop to save repeated code.
+    for key, needs_changed in [(YMLSTR.limits, limits), (YMLSTR.requests, requests)]:
+        if needs_changed is None:
+            changed[key] = None
+            continue
+
+        # We use .get() here because we don't want to raise an error if the key
+        # doesn't exist.
+        changed[key] = K8sResourceOptions(
+            cpu=int(needs_changed.get(YMLSTR.cpu, DEFAULT_CPU)),
+            memory=str(needs_changed.get(YMLSTR.memory, DEFAULT_MEMORY)),
+            nvidia_gpu=needs_changed.get(YMLSTR.nvidia_gpu, None),
+            amd_gpu=needs_changed.get(YMLSTR.amd_gpu, None),
+        )
+
+    return K8sResources(
+        limits=changed[YMLSTR.limits],
+        requests=changed[YMLSTR.requests],
+    )
+
+
+def get_submissions(file) -> List[Submission]:
+    """
+    Creates the submissions from a YAML file
+    """
+
+    submissions = []
+
+    with open(file, "r", encoding="utf-8") as f:
+        config = yaml.load(f, Loader=yaml.FullLoader)
+
+        for submission in config[YMLSTR.submissions]:
+
+            # pop out resources key
+            resources = submission.pop(YMLSTR.resources, None)
+
+            # check for missing mandatory keys
+            for key in [YMLSTR.name, YMLSTR.image]:
+                if key not in submission:
+                    raise ValueError(f"Missing mandatory key {key}")
+
+            # create submission object
+            # We use .get() for the optional keys so that we don't raise an error
+            submission = Submission(
+                name=submission[YMLSTR.name],
+                image=submission[YMLSTR.image],
+                armada_queue=submission.get(YMLSTR.armada_queue, DEFAULT_QUEUE),
+                armada_priority=submission.get(
+                    YMLSTR.armada_priority, DEFAULT_PRIORITY
+                ),
+                timeout=submission.get(YMLSTR.timeout, DEFAULT_TIMEOUT),
+            )
+
+            # Insert resources seperately. This is because we need want to
+            # support both a dict and a K8sResources object.
+            if resources:
+                submission.resources_from_dict(resources)
+
+            submissions.append(submission)
+
+    return submissions

--- a/armada_jupyter/submissions.py
+++ b/armada_jupyter/submissions.py
@@ -143,8 +143,8 @@ def k8s_resources_from_dict(
 
     changed: Dict[str, Optional[K8sResourceOptions]] = {}
 
-    if limits is None and requests is None:
-        raise ValueError("Must specify at least one of limits or requests")
+    if limits is None or requests is None:
+        raise ValueError("Must specify both limits and requests")
 
     # Use a loop to save repeated code.
     for key, needs_changed in [(YMLSTR.limits, limits), (YMLSTR.requests, requests)]:

--- a/armada_jupyter/submissions.py
+++ b/armada_jupyter/submissions.py
@@ -29,6 +29,11 @@ class K8sResourceOptions:
         self.nvidia_gpu = nvidia_gpu
         self.amd_gpu = amd_gpu
 
+        if self.nvidia_gpu and self.amd_gpu:
+            raise ValueError(
+                "Both nvidia_gpu and amd_gpu cannot be set at the same time."
+            )
+
         # If they exist, they might be a string, so we need to convert them to int
         if self.nvidia_gpu:
             self.nvidia_gpu = int(self.nvidia_gpu)
@@ -51,8 +56,8 @@ class K8sResources:
     def __init__(
         self, limits: K8sResourceOptions = None, requests: K8sResourceOptions = None
     ):
-        if limits is None and requests is None:
-            raise ValueError("Must specify at least one of limits or requests")
+        if limits is None or requests is None:
+            raise ValueError("Must specify both limits and requests")
 
         self.limits = limits
         self.requests = limits
@@ -105,8 +110,7 @@ class Submission:
         elif timeout[-1] == "s":
             return timeout
 
-        ValueError("Timeout must be in the form of [x]h, [x]m or [x]s")
-        return None
+        raise ValueError("Timeout must be in the form of [x]h, [x]m or [x]s")
 
     def resources_from_dict(
         self, resources: Dict[str, Dict[str, Union[str, int]]]

--- a/docs/design/initial-design.md
+++ b/docs/design/initial-design.md
@@ -36,7 +36,7 @@ version: "0.1"
 submissions:
 - name: "JupyterLab"
   image: "jupyter/tensorflow-notebook:latest"
-  timeout: 36hrs
+  timeout: 36h
   resources:
     cpu: 1
     memory: 1Gi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Submit JupyterLab Pods to Armada"
 readme = "README.md"
 requires-python = ">=3.7,<3.10"
-dependencies = ["armada_client", "typer"]
+dependencies = ["armada_client", "typer", "pyyaml", "types-PyYAML"]
 license = { text = "Apache Software License" }
 authors = [{ name = "G-Research Open Source Software", email = "armada@armadaproject.io" }]
 

--- a/tests/files/test_sub_full.yml
+++ b/tests/files/test_sub_full.yml
@@ -7,7 +7,7 @@ submissions:
   armada_queue: "default"
   armada_priority: 1
 
-  # We Support "h" and "mins" for time
+  # We Support "h" and "m" for hours and minutes
   timeout: 36h
 
   # Resources are based on the Kubernetes resource model
@@ -18,7 +18,6 @@ submissions:
 
       # for gpu, we support "nvidia.com/gpu" and "amd.com/gpu"
       nvidia.com/gpu: 1
-      amd.com/gpu: 2
 
     requests:
       cpu: 1
@@ -26,4 +25,3 @@ submissions:
 
       # for gpu, we support "nvidia.com/gpu" and "amd.com/gpu"
       nvidia.com/gpu: 1
-      amd.com/gpu: 2

--- a/tests/files/test_sub_full.yml
+++ b/tests/files/test_sub_full.yml
@@ -7,7 +7,7 @@ submissions:
   armada_queue: "default"
   armada_priority: 1
 
-  # We Support "h" and "m" for hours and minutes
+  # We Support "h" and "mins" for time
   timeout: 36h
 
   # Resources are based on the Kubernetes resource model
@@ -18,6 +18,7 @@ submissions:
 
       # for gpu, we support "nvidia.com/gpu" and "amd.com/gpu"
       nvidia.com/gpu: 1
+      amd.com/gpu: 2
 
     requests:
       cpu: 1
@@ -25,3 +26,4 @@ submissions:
 
       # for gpu, we support "nvidia.com/gpu" and "amd.com/gpu"
       nvidia.com/gpu: 1
+      amd.com/gpu: 2

--- a/tests/files/test_sub_no_req.yml
+++ b/tests/files/test_sub_no_req.yml
@@ -7,5 +7,5 @@ submissions:
   armada_queue: "default"
   armada_priority: 1
 
-  # We Support "h" and "mins" for time
+  # We Support "h" and "m" for hours and minutes
   timeout: 36h

--- a/tests/files/test_sub_no_req.yml
+++ b/tests/files/test_sub_no_req.yml
@@ -1,0 +1,11 @@
+version: "0.1"
+
+submissions:
+- name: "JupyterLab"
+  image: "jupyter/tensorflow-notebook:latest"
+
+  armada_queue: "default"
+  armada_priority: 1
+
+  # We Support "h" and "mins" for time
+  timeout: 36h

--- a/tests/files/test_sub_small.yml
+++ b/tests/files/test_sub_small.yml
@@ -1,0 +1,5 @@
+version: "0.1"
+
+submissions:
+- name: "JupyterLab"
+  image: "jupyter/tensorflow-notebook:latest"

--- a/tests/files/test_sub_small_req.yml
+++ b/tests/files/test_sub_small_req.yml
@@ -7,11 +7,15 @@ submissions:
   armada_queue: "default"
   armada_priority: 1
 
-  # We Support "h" and "mins" for time
+  # We Support "h" and "m" for hours and minutes
   timeout: 36h
 
   # Resources are based on the Kubernetes resource model
   resources:
     limits:
+      cpu: 1
+      memory: 1Gi
+
+    requests:
       cpu: 1
       memory: 1Gi

--- a/tests/files/test_sub_small_req.yml
+++ b/tests/files/test_sub_small_req.yml
@@ -1,0 +1,17 @@
+version: "0.1"
+
+submissions:
+- name: "JupyterLab"
+  image: "jupyter/tensorflow-notebook:latest"
+
+  armada_queue: "default"
+  armada_priority: 1
+
+  # We Support "h" and "mins" for time
+  timeout: 36h
+
+  # Resources are based on the Kubernetes resource model
+  resources:
+    limits:
+      cpu: 1
+      memory: 1Gi

--- a/tests/unit/test_submission_class.py
+++ b/tests/unit/test_submission_class.py
@@ -19,8 +19,8 @@ fake_submission_full = Submission(
     armada_priority=1,
     timeout="36h",
     resources=K8sResources(
-        limits=K8sResourceOptions(cpu=1, memory="1Gi", nvidia_gpu=1, amd_gpu=2),
-        requests=K8sResourceOptions(cpu=1, memory="1Gi", nvidia_gpu=1, amd_gpu=2),
+        limits=K8sResourceOptions(cpu=1, memory="1Gi", nvidia_gpu=1),
+        requests=K8sResourceOptions(cpu=1, memory="1Gi", nvidia_gpu=1),
     ),
 )
 
@@ -40,6 +40,7 @@ fake_submission_small_req = Submission(
     timeout="36h",
     resources=K8sResources(
         limits=K8sResourceOptions(cpu=1, memory="1Gi"),
+        requests=K8sResourceOptions(cpu=1, memory="1Gi"),
     ),
 )
 

--- a/tests/unit/test_submission_class.py
+++ b/tests/unit/test_submission_class.py
@@ -1,0 +1,92 @@
+"""
+Testing Config class
+"""
+
+import pytest
+
+from armada_jupyter.submissions import (
+    get_submissions,
+    Submission,
+    K8sResources,
+    K8sResourceOptions,
+)
+
+
+fake_submission_full = Submission(
+    name="JupyterLab",
+    image="jupyter/tensorflow-notebook:latest",
+    armada_queue="default",
+    armada_priority=1,
+    timeout="36h",
+    resources=K8sResources(
+        limits=K8sResourceOptions(cpu=1, memory="1Gi", nvidia_gpu=1, amd_gpu=2),
+        requests=K8sResourceOptions(cpu=1, memory="1Gi", nvidia_gpu=1, amd_gpu=2),
+    ),
+)
+
+fake_submission_no_req = Submission(
+    name="JupyterLab",
+    image="jupyter/tensorflow-notebook:latest",
+    armada_queue="default",
+    armada_priority=1,
+    timeout="36h",
+)
+
+fake_submission_small_req = Submission(
+    name="JupyterLab",
+    image="jupyter/tensorflow-notebook:latest",
+    armada_queue="default",
+    armada_priority=1,
+    timeout="36h",
+    resources=K8sResources(
+        limits=K8sResourceOptions(cpu=1, memory="1Gi"),
+    ),
+)
+
+fake_submission_small = Submission(
+    name="JupyterLab",
+    image="jupyter/tensorflow-notebook:latest",
+    armada_queue="default",
+    armada_priority=1,
+    timeout="1h",
+)
+
+
+@pytest.mark.parametrize(
+    "file, fake_submission",
+    [
+        ("tests/files/test_sub_full.yml", fake_submission_full),
+        ("tests/files/test_sub_no_req.yml", fake_submission_no_req),
+        ("tests/files/test_sub_small_req.yml", fake_submission_small_req),
+        ("tests/files/test_sub_small.yml", fake_submission_small),
+    ],
+)
+def test_submission_gen(file, fake_submission):
+    """
+    Test get_config function
+    """
+
+    configs = get_submissions(file)
+    assert str(configs[0]) == str(
+        fake_submission
+    ), f"{configs[0]} \n\n {fake_submission} \n\n"
+
+    assert configs[0].timeout == fake_submission.timeout
+
+
+@pytest.mark.parametrize(
+    "file, real_timeout",
+    [
+        ("tests/files/test_sub_full.yml", "129600s"),
+        ("tests/files/test_sub_no_req.yml", "129600s"),
+        ("tests/files/test_sub_small_req.yml", "129600s"),
+        ("tests/files/test_sub_small.yml", "3600s"),
+    ],
+)
+def test_submission_timeout(file, real_timeout):
+    """
+    Test get_config function
+    """
+
+    configs = get_submissions(file)
+    assert configs[0].timeout == real_timeout

--- a/tests/unit/test_submission_funcs.py
+++ b/tests/unit/test_submission_funcs.py
@@ -11,13 +11,11 @@ from armada_jupyter.submissions import (
     "limits, requests, expected",
     [
         (
-            {"cpu": 1, "memory": "1Gi", "nvidia.com/gpu": 1, "amd.com/gpu": 2},
-            {"cpu": 1, "memory": "1Gi", "nvidia.com/gpu": 1, "amd.com/gpu": 2},
+            {"cpu": 1, "memory": "1Gi", "nvidia.com/gpu": 1},
+            {"cpu": 1, "memory": "1Gi", "nvidia.com/gpu": 1},
             K8sResources(
-                limits=K8sResourceOptions(cpu=1, memory="1Gi", nvidia_gpu=1, amd_gpu=2),
-                requests=K8sResourceOptions(
-                    cpu=1, memory="1Gi", nvidia_gpu=1, amd_gpu=2
-                ),
+                limits=K8sResourceOptions(cpu=1, memory="1Gi", nvidia_gpu=1),
+                requests=K8sResourceOptions(cpu=1, memory="1Gi", nvidia_gpu=1),
             ),
         ),
         (

--- a/tests/unit/test_submission_funcs.py
+++ b/tests/unit/test_submission_funcs.py
@@ -1,0 +1,39 @@
+import pytest
+
+from armada_jupyter.submissions import (
+    K8sResources,
+    K8sResourceOptions,
+    k8s_resources_from_dict,
+)
+
+
+@pytest.mark.parametrize(
+    "limits, requests, expected",
+    [
+        (
+            {"cpu": 1, "memory": "1Gi", "nvidia.com/gpu": 1, "amd.com/gpu": 2},
+            {"cpu": 1, "memory": "1Gi", "nvidia.com/gpu": 1, "amd.com/gpu": 2},
+            K8sResources(
+                limits=K8sResourceOptions(cpu=1, memory="1Gi", nvidia_gpu=1, amd_gpu=2),
+                requests=K8sResourceOptions(
+                    cpu=1, memory="1Gi", nvidia_gpu=1, amd_gpu=2
+                ),
+            ),
+        ),
+        (
+            {"cpu": 1, "memory": "1Gi"},
+            {"cpu": 1, "memory": "1Gi"},
+            K8sResources(
+                limits=K8sResourceOptions(cpu=1, memory="1Gi"),
+                requests=K8sResourceOptions(cpu=1, memory="1Gi"),
+            ),
+        ),
+    ],
+)
+def test_k8s_resources_from_dict(limits, requests, expected):
+    """
+    Test k8s_resources_from_dict function
+    """
+
+    resources = k8s_resources_from_dict(limits, requests)
+    assert str(resources) == str(expected), f"{resources} \n\n {expected} \n\n"


### PR DESCRIPTION
Closes #13 

I ended up doing the mapping myself:

- I wanted users to be able to construct config with either python code or config files (Mostly for testing right now but maybe with changes as we go through development), which is not easily supported in pyyaml.
- I also knew that there would need to be a lot of custom code to support what is mandatory, what is optional etc, so decided a manual approach was better.
- Getting the nested code to work was going to require 3 classes anyways with config to change certain options types.

For future-proofing changes to the config, I store all the names in [armada_jupyter/constants.py](https://github.com/G-Research/armada-jupyter/pull/30/files#diff-699a0c7102d748707809c6982e3723ead35259fd5c6e4f3077b77ce059a09bd8), so they can be easily changed and adapted later.

I am not going to lie, maybe I did this really inefficiently and there is a better solution in python, but I _know_ that this is way easier in golang. I am not telling anyone off with this comment, as I did not think of this either, but definitely something to remember for the future.

My hope is that a demo tommorow is still possible as the other 3 PR's I need to make are quite small (relative to this one), and a few of them can be done in parallel, which is ideal.